### PR TITLE
Add support for specifying the leaderboard size limit

### DIFF
--- a/backend/routes/scores/getDailyChallengeScores.ts
+++ b/backend/routes/scores/getDailyChallengeScores.ts
@@ -4,7 +4,7 @@ import queryTopScores from '@backend/queries/topScores'
 import { getUserId, throwError, todayEnd, todayStart } from '@backend/utils'
 
 const getScoresHelper = async (userId: string | undefined, query: any, res: NextApiResponse, limit: number | undefined) => {
-  const data = await queryTopScores(query, limit || 5)
+  const data = await queryTopScores(query, limit ? Math.min(limit, 200): 5);
 
   if (!data) {
     return throwError(res, 404, 'Failed to get scores for The Daily Challenge')

--- a/backend/routes/scores/getDailyChallengeScores.ts
+++ b/backend/routes/scores/getDailyChallengeScores.ts
@@ -3,14 +3,14 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import queryTopScores from '@backend/queries/topScores'
 import { getUserId, throwError, todayEnd, todayStart } from '@backend/utils'
 
-const getScoresHelper = async (userId: string | undefined, query: any, res: NextApiResponse) => {
-  const data = await queryTopScores(query, 5)
+const getScoresHelper = async (userId: string | undefined, query: any, res: NextApiResponse, limit: number | undefined) => {
+  const data = await queryTopScores(query, limit || 5)
 
   if (!data) {
     return throwError(res, 404, 'Failed to get scores for The Daily Challenge')
   }
 
-  // Determine if this user is in the top 5 (If yes -> mark them as highlight: true)
+  // Determine if this user is in the top list (If yes -> mark them as highlight: true)
   const thisUserIndex = data.findIndex((user) => user?.userId?.toString() === userId)
   const isUserInTopFive = thisUserIndex !== -1
 
@@ -19,7 +19,7 @@ const getScoresHelper = async (userId: string | undefined, query: any, res: Next
     return data
   }
 
-  // If this user is not in the top 5 -> Get their top score and mark them as highlight: true
+  // If this user is not in the top list -> Get their top score and mark them as highlight: true
   const thisUserQuery = { userId: new ObjectId(userId), ...query }
   const thisUserData = await queryTopScores(thisUserQuery, 1)
 
@@ -31,13 +31,14 @@ const getScoresHelper = async (userId: string | undefined, query: any, res: Next
 }
 
 const getDailyChallengeScores = async (req: NextApiRequest, res: NextApiResponse) => {
+  const limit = req.query.limit ? parseInt(req.query.limit as string) : undefined;
   const userId = await getUserId(req, res)
 
   const allTimeQuery = { isDailyChallenge: true, state: 'finished' }
   const todayQuery = { isDailyChallenge: true, state: 'finished', createdAt: { $gte: todayStart, $lt: todayEnd } }
 
-  const allTimeData = await getScoresHelper(userId, allTimeQuery, res)
-  const todayData = await getScoresHelper(userId, todayQuery, res)
+  const allTimeData = await getScoresHelper(userId, allTimeQuery, res, limit)
+  const todayData = await getScoresHelper(userId, todayQuery, res, limit)
 
   const result = {
     allTime: allTimeData,


### PR DESCRIPTION
This PR adds the `limit` query parameter to leaderboard queries. It is not used by the frontend, and the default is still 5, but it is available for others using the API directly.

For performance reasons it would probably be better to store the results in a separate collection, and not run the aggregation query every time, but it is out of scope for this PR.