### PR TITLE
Remove Germany is blurred tip from geotips.json

### DIFF
--- a/utils/constants/geotips.json
+++ b/utils/constants/geotips.json
@@ -5,11 +5,6 @@
     "image": ""
   },
   {
-    "tip": "In Germany, many areas are often blurred out",
-    "tags": ["Beginner", "Europe", "Germany"],
-    "image": ""
-  },
-  {
     "tip": "Italy license plates are more narrow than standard EU plates and have blue strips on both sides",
     "tags": ["Beginner", "Italy", "License Plates"],
     "image": ""


### PR DESCRIPTION
Remove Germany tip, not applicable due to Issue #62