### PR TITLE
[enhancement] Docker: Add docker support w Dockerfile & docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# docker volumes
+database/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14
+
+WORKDIR /usr/src/app
+
+COPY package.json yarn.lock ./
+
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+RUN yarn build
+
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ yarn dev
 
 Now, you should be able to see the site running locally at [http://localhost:3000](http://localhost:3000)
 
+## 🐳 Docker
+
+You can also easily run the app using Docker and Docker Compose. To do this, first clone the repository. Get your Google Maps API key as explained above. Generate two random secrets for NextAuth and Cryptr with the `openssl rand -base64 32` command. Then, create a `.env` file in the root of the project with the following content:
+
+```env
+NEXT_PUBLIC_GOOGLE_API_KEY="your-google-maps-key"
+MONGO_INITDB_ROOT_USERNAME="root"
+MONGO_INITDB_ROOT_PASSWORD="example" # Change this to a strong password
+DB_NAME="geohub"
+NEXTAUTH_SECRET="your-first-random-secret"
+CRYPTR_SECRET="your-second-random-secret"
+```
+
+Then, run the following command to start the app:
+```bash
+sudo docker compose up # Add -d flag to run in headless mode
+```
+
+Now, you should be able to see the site running locally at [http://localhost:3000](http://localhost:3000)
+
 ## 🚀 Tech Stack
 
 - ✅ **Framework**: [Nextjs + Typescript](https://nextjs.org)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.9"
+services:
+  geohub:
+    build:
+      context: .
+    env_file:
+      - .env
+    environment:
+      MONGO_URI: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongo:27017
+    volumes:
+      - .env:/usr/src/app/.env
+    ports:
+      - "3000:3000"
+  mongo:
+    image: mongo
+    restart: always
+    env_file:
+      - .env
+    volumes:
+      - ./database:/data/db


### PR DESCRIPTION
Adding docker support with a Dockerfile and a docker-compose.

I noticed that, in the self hosted version, the default maps were not present. If this is expected behavior then this should do the work. If not, please let me know.

Also, could you please confirm that no content is stored outside of the database. **If this is at any point the case, please inform me before so that I can map any folder to a docker volume, as if it is not done all data would be lost between restarts.**

Other than that, great work, this project is very nice and I am happy to help