### PR TITLE
Fixed padding on daily challenges

### DIFF
--- a/components/DailyChallengeWinners/DailyChallengeWinners.Styled.tsx
+++ b/components/DailyChallengeWinners/DailyChallengeWinners.Styled.tsx
@@ -36,6 +36,8 @@ const StyledDailyChallengeWinners = styled.div<StyledProps>`
   .notPlayedMsg {
     color: var(--color4);
     font-weight: 400;
+    display: block;
+    padding: 0px 20px 20px;
   }
 `
 


### PR DESCRIPTION
Added padding and set display to align the message when noone has played a daily challenge

Old:
![image](https://github.com/user-attachments/assets/f5380b48-975f-4d1d-a874-8c23f22d4e93)

New:
![image](https://github.com/user-attachments/assets/0102f6ab-00af-4d53-ae4b-538692d4ff83)
