### PR TITLE
Allow to fetch basic challenge results without having played the challenge

### DIFF
--- a/pages/results/challenge/[id].tsx
+++ b/pages/results/challenge/[id].tsx
@@ -33,10 +33,6 @@ const ChallengeResultsPage: PageType = () => {
     }
 
     if (res.error) {
-      if (res.error.code === 401) {
-        return setNotAuthorized(true)
-      }
-
       return setGamesFromChallenge(null)
     }
 

--- a/pages/results/challenge/[id].tsx
+++ b/pages/results/challenge/[id].tsx
@@ -28,6 +28,10 @@ const ChallengeResultsPage: PageType = () => {
   const fetchGames = async () => {
     const res = await mailman(`scores/challenges/${challengeId}`)
 
+    if (res.notPlayed) {
+      return setNotAuthorized(true)
+    }
+
     if (res.error) {
       if (res.error.code === 401) {
         return setNotAuthorized(true)


### PR DESCRIPTION
Hello. This PR makes it possible to get challenge results without having played the challenge yourself. In this case only scores and overall distance is returned, and not the exact rounds/guesses that tell you the actual location.

Here's the reason why I want this to be possible: we have a group chat with several people playing geohub, and we used to have a bot that would post a notification whenever someone from the group would finish the daily challenge and what score they got. This was a really cool thing to have, but unfortunately after some of the API changes on the geohub side it became impossible to do this anymore (short of scanning through the entire game history of every user to try and find today's daily). With this it will be possible again with only a single API call.

I have tested that this works correctly locally, and in the frontend the behaviour is the same as before (it will show an error if you try and open the results screen for a challenge you haven't played).